### PR TITLE
Add task to download and extract a world archive.

### DIFF
--- a/tasks/hooks/after-install/world.yml
+++ b/tasks/hooks/after-install/world.yml
@@ -1,0 +1,29 @@
+- name: create world directory
+  file:
+    path: "{{ minecraft_home }}/world"
+    state: directory
+    owner: "{{ minecraft_user }}"
+    group: "{{ minecraft_user }}"
+
+- name: create temp directory
+  file:
+    path: /tmp/ansible-minecraft
+    state: directory
+    owner: "{{ minecraft_user }}"
+    group: "{{ minecraft_user }}"
+
+- name: download world
+  get_url:
+    url: "{{ minecraft_world_url }}"
+    dest: /tmp/ansible-minecraft/world
+    owner: "{{ minecraft_user }}"
+    group: "{{ minecraft_user }}"
+
+- name: unarchive world
+  unarchive:
+    creates: "{{ minecraft_home }}/world/data"
+    copy: no
+    src: /tmp/ansible-minecraft/world
+    dest: "{{ minecraft_home }}/world"
+    owner: "{{ minecraft_user }}"
+    group: "{{ minecraft_user }}"


### PR DESCRIPTION
I created an after-install task that downloads and extracts an archived world. The world can be archived in any format supported by ansible's `unarchive` module, which handily also autodetects the format, so we can download it to a generic, extension-less filename.

I don't have any docs right now, but I can easily whip some up if you're interested in including this in core.
