### PR TITLE
Feature - Add Vagrant Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *~
+
+#Vagrant Files
+.vagrant/*

--- a/README.rst
+++ b/README.rst
@@ -217,12 +217,11 @@ This role includes a Vagrantfile used with a Docker-based test harness for integ
 
 5. Test the role against each Dockerfile with ``make``:
 
-  ::
+   ::
 
        make jessie64 test
        make centos7 test
        make xenial64 test
-
 
 Integration tests use **systemd** by default. Set ``PROCESS_CONTROL`` to change this:
 

--- a/README.rst
+++ b/README.rst
@@ -205,23 +205,43 @@ If you'd like to help with the project itself, here are some other ways you can 
 
 Testing
 ~~~~~~~
-This role includes a Vagrantfile used with a Docker-based test harness for integration testing. Using Vagrant allows all contributors to test on the same platform and avoid false test failures due to untested or incompatible docker versions.
+Testing can be done using the provided Vagrantfile or by installing `Docker <https://docs.docker.com/engine/installation/>`__ and `Docker Compose <https://docs.docker.com/compose/>`__ locally.
+
+Testing with Vagrant
+"""""""""""""""""""""
+This role includes a Vagrantfile used with a Docker-based test harness that approximates the Travis CI setup for integration testing. Using Vagrant allows all contributors to test on the same platform and avoid false test failures due to untested or incompatible docker versions.
 
 1. Install `Vagrant <https://www.vagrantup.com/>`__ and `VirtualBox <https://www.virtualbox.org/>`__.
 
 2. Run ``vagrant up`` from the same directory as the Vagrantfile in this repository.
 
-3. SSH into the VM with: ``vagrant ssh`` or ``ssh 127.0.0.1:2222`` or ``ssh 10.1.15.10``
+3. SSH into the VM with: ``vagrant ssh``
 
-4. Change directories into **/vagrant** with the command: ``cd /vagrant``
+4. Run tests with ``make``.
 
-5. Test the role against each Dockerfile with ``make``:
+   ::
+
+       make -C /vagrant xenial64 test
+
+Integration tests use **systemd** by default. Set ``PROCESS_CONTROL`` to change this:
+
+::
+
+    make -C /vagrant trusty64 test PROCESS_CONTROL=supervisor
+
+See ``make help`` for more information including a full list of available targets.
+
+Testing with Docker and Docker Compose locally
+""""""""""""""""""""""""""""""""""""""""""""""""
+Alternatively, you can install `Docker <https://docs.docker.com/engine/installation/>`__ and `Docker Compose <https://docs.docker.com/compose/>`__ to run these tests locally on your machine.
+
+1. Install `Docker <https://docs.docker.com/engine/installation/>`__ and `Docker Compose <https://docs.docker.com/compose/>`__.
+
+2. Run tests with ``make``.
 
    ::
 
        make jessie64 test
-       make centos7 test
-       make xenial64 test
 
 Integration tests use **systemd** by default. Set ``PROCESS_CONTROL`` to change this:
 
@@ -229,7 +249,7 @@ Integration tests use **systemd** by default. Set ``PROCESS_CONTROL`` to change 
 
     make trusty64 test PROCESS_CONTROL=supervisor
 
-See ``make help`` for more information.
+See ``make help`` for more information including a full list of available targets.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -205,16 +205,24 @@ If you'd like to help with the project itself, here are some other ways you can 
 
 Testing
 ~~~~~~~
+This role includes a Vagrantfile used with a Docker-based test harness for integration testing. Using Vagrant allows all contributors to test on the same platform and avoid false test failures due to untested or incompatible docker versions.
 
-This role includes a Docker-based test harness for integration testing.
+1. Install `Vagrant <https://www.vagrantup.com/>`__ and `VirtualBox <https://www.virtualbox.org/>`__.
 
-1. Install `Docker <https://docs.docker.com/engine/installation/>`__ and `Docker Compose <https://docs.docker.com/compose/>`__.
+2. Run ``vagrant up`` from the same directory as the Vagrantfile in this repository.
 
-2. Run tests with ``make``.
+3. SSH into the VM with: ``vagrant ssh`` or ``ssh 127.0.0.1:2222`` or ``ssh 10.1.15.10``
 
-   ::
+4. Change directories into **/vagrant** with the command: ``cd /vagrant``
+
+5. Test the role against each Dockerfile with ``make``:
+
+  ::
 
        make jessie64 test
+       make centos7 test
+       make xenial64 test
+
 
 Integration tests use **systemd** by default. Set ``PROCESS_CONTROL`` to change this:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,47 @@
+# Defines our Vagrant environment
+#
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+my_machines={
+# 'hostname' => ['IPAddress','Memory in MB','Number of CPUs'],
+  'node1'  => ['10.1.15.10','1024','1']
+}
+
+$setupScript = <<SCRIPT
+echo provisioning docker...
+sudo apt-get update
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-add-repository 'deb https://apt.dockerproject.org/repo ubuntu-trusty main'
+sudo apt-get update
+sudo apt-get -o Dpkg::Options::="--force-confnew" install --force-yes -y docker-engine=1.10.2-0~trusty
+sudo usermod -a -G docker vagrant
+curl -L "https://github.com/docker/compose/releases/download/1.6.2/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+docker version
+
+docker-compose version
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "bento/ubuntu-14.04"
+
+  my_machines.each do |short_name, array|
+
+    config.vm.define short_name do |host|
+      host.vm.network 'private_network', ip: array[0]
+      host.vm.hostname = "#{short_name}"
+      host.vm.provider "virtualbox" do |vb|
+        vb.memory = "#{array[1]}"
+        vb.cpus = "#{array[2]}"
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+        vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      end
+      host.vm.provision :shell, :inline => $setupScript
+    end
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,11 +6,6 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-my_machines={
-# 'hostname' => ['IPAddress','Memory in MB','Number of CPUs'],
-  'node1'  => ['10.1.15.10','1024','1']
-}
-
 $setupScript = <<SCRIPT
 echo provisioning docker...
 sudo apt-get update
@@ -19,8 +14,9 @@ sudo apt-add-repository 'deb https://apt.dockerproject.org/repo ubuntu-trusty ma
 sudo apt-get update
 sudo apt-get -o Dpkg::Options::="--force-confnew" install --force-yes -y docker-engine=1.10.2-0~trusty
 sudo usermod -a -G docker vagrant
-curl -L "https://github.com/docker/compose/releases/download/1.6.2/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
+sudo apt-get install python3-pip -y && sudo pip3 install --upgrade pip
+sudo pip install docker-compose==1.6.2
+
 docker version
 
 docker-compose version
@@ -28,20 +24,15 @@ SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "bento/ubuntu-14.04"
-
-  my_machines.each do |short_name, array|
-
-    config.vm.define short_name do |host|
-      host.vm.network 'private_network', ip: array[0]
-      host.vm.hostname = "#{short_name}"
-      host.vm.provider "virtualbox" do |vb|
-        vb.memory = "#{array[1]}"
-        vb.cpus = "#{array[2]}"
-        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-        vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
-      end
-      host.vm.provision :shell, :inline => $setupScript
+  config.vm.define "server" do |host|
+    host.vm.hostname = "server"
+    host.vm.provider "virtualbox" do |vb|
+      vb.memory = "1024"
+      vb.cpus = "1"
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
     end
+    host.vm.provision :shell, :inline => $setupScript
   end
 end


### PR DESCRIPTION
I've added a Vagrantfile which uses an Ubuntu14.04 box matching the same `docker-engine` and `docker-compose` versions used from `install-docker.sh` for Travis tests.

This should offer a standard platform between any contributors interested in testing with the same version of docker that Travis is using for tests. I have on more than one occasion had tests pass locally only to fail in Travis before a PR because the docker-engine version used in Travis had some weird compatibility issues with certain Ansible versions.