### PR TITLE
Set default permission mode via stat values

### DIFF
--- a/library/minecraft_server_file.py
+++ b/library/minecraft_server_file.py
@@ -59,7 +59,9 @@ class FileStats(object):
         self.path = os.path.expanduser(module.params['path'])
         self.owner = module.params['owner']
         self.group = module.params['group']
-        self.mode = module.params['mode'] if module.params['mode'] else 0644
+        # Python version agnostic way of setting permissions 0644
+        perm_0644 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+        self.mode = module.params['mode'] if module.params['mode'] else perm_0644
 
     @property
     def changed(self):

--- a/library/minecraft_server_file.py
+++ b/library/minecraft_server_file.py
@@ -59,9 +59,7 @@ class FileStats(object):
         self.path = os.path.expanduser(module.params['path'])
         self.owner = module.params['owner']
         self.group = module.params['group']
-        # Python version agnostic way of setting permissions 0644
-        perm_0644 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
-        self.mode = module.params['mode'] if module.params['mode'] else perm_0644
+        self.mode = module.params['mode'] if module.params['mode'] else 0o644
 
     @property
     def changed(self):


### PR DESCRIPTION
The existing value is invalid python3, and will result in a difficult to track runtime error. To support compatibility with python2.x and 3.x, I've changed this to use permission bitmasks from the stat library.

I figured I'd get approval from someone in the team before merging.