### PR TITLE
Needs the download directory prefix

### DIFF
--- a/tasks/install/spigot.yml
+++ b/tasks/install/spigot.yml
@@ -1,4 +1,4 @@
-- include: latest.yml
+- include: download/latest.yml
   when: minecraft_version == 'latest'
 
 - name: build Spigot server


### PR DESCRIPTION
Looks like the spigot.yml was missing the `download/` prefix (where the `latest.yml` file lives) as this was failing for me:

```
ansible-playbook -i spigot.example.com, playbook.yml

[DEPRECATION WARNING]: Included file '/Users/jay/ansible-minecraft/latest.yml' not found, however since this include is not explicitly marked as 'static: yes', we will try and include it
dynamically later. In the future, this will be an error unless 'static: no' is used on the include task. If you do not want missing includes to be considered dynamic, use 'static: yes' on the include or
set the global ansible.cfg options to make all includes static for tasks and/or handlers. This feature will be removed in version 2.7. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

The attached PR means that spigot now builds and runs